### PR TITLE
Fixes migrate callback running multiple times

### DIFF
--- a/ios/FIRAuthMigrator.m
+++ b/ios/FIRAuthMigrator.m
@@ -244,6 +244,7 @@
     // Someone's already logged in, so clear the legacy token and keep using the current user.
     [self clearLegacyAuth];
     callback(currentUser, nil);
+    return;
   }
 
   // Get the legacy token out of the keychain.


### PR DESCRIPTION
Fixes a bug where if someone is already authenticated with the current Firebase SDK `migrate:` would run the callback twice.
